### PR TITLE
Add Notes field to Add and Edit Transaction modals

### DIFF
--- a/migrations/0005_transaction_notes.sql
+++ b/migrations/0005_transaction_notes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE recurring_transactions ADD COLUMN notes TEXT;
+ALTER TABLE adhoc_transactions ADD COLUMN notes TEXT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,9 +1017,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1037,9 +1034,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1057,9 +1051,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1077,9 +1068,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1097,9 +1085,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1117,9 +1102,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1137,9 +1119,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1157,9 +1136,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1177,9 +1153,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1203,9 +1176,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1229,9 +1199,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1255,9 +1222,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1281,9 +1245,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1307,9 +1268,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1333,9 +1291,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1359,9 +1314,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1635,9 +1587,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1652,9 +1601,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1669,9 +1615,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1686,9 +1629,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1703,9 +1643,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1720,9 +1657,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1737,9 +1671,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1754,9 +1685,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1771,9 +1699,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,9 +1713,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1805,9 +1727,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1822,9 +1741,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1839,9 +1755,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2085,9 +1998,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2105,9 +2015,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2125,9 +2032,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2145,9 +2049,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2796,9 +2697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2820,9 +2718,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2844,9 +2739,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2868,9 +2760,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -32,6 +32,7 @@ const DEFAULT_RECURRING: Omit<RecurringTransaction, 'id' | 'active' | 'created_a
   day_of_week: null,
   nth_week: null,
   biweekly_anchor: null,
+  notes: null,
 }
 
 export default function TransactionModal({
@@ -59,11 +60,15 @@ export default function TransactionModal({
   const [rNthWeek, setRNthWeek] = useState(editRecurring?.nth_week ?? 1)
   const [rAnchor, setRAnchor] = useState(editRecurring?.biweekly_anchor ?? '')
 
+  // Recurring notes state
+  const [rNotes, setRNotes] = useState(editRecurring?.notes ?? '')
+
   // One-time form state
   const [aType, setAType] = useState<TransactionType>('expense')
   const [aName, setAName] = useState('')
   const [aAmount, setAAmount] = useState('')
   const [aDate, setADate] = useState(initialDate ?? new Date().toISOString().slice(0, 10))
+  const [aNotes, setANotes] = useState(editAdhoc?.notes ?? '')
 
   useEffect(() => {
     if (!open) return
@@ -75,6 +80,7 @@ export default function TransactionModal({
       setAName(editAdhoc.name)
       setAAmount(String(editAdhoc.amount))
       setADate(editAdhoc.date)
+      setANotes(editAdhoc.notes ?? '')
       return
     }
 
@@ -91,12 +97,14 @@ export default function TransactionModal({
     setRDayOfWeek(editRecurring?.day_of_week ?? 5)
     setRNthWeek(editRecurring?.nth_week ?? 1)
     setRAnchor(editRecurring?.biweekly_anchor ?? '')
+    setRNotes(editRecurring?.notes ?? '')
 
     // Reset one-time fields
     setAType('expense')
     setAName('')
     setAAmount('')
     setADate(initialDate ?? new Date().toISOString().slice(0, 10))
+    setANotes('')
   }, [open, initialDate, editRecurring, editAdhoc])
 
   if (!open) return null
@@ -121,6 +129,7 @@ export default function TransactionModal({
           day_of_week: ['weekly', 'biweekly', 'monthly_nth_weekday'].includes(rRecType) ? rDayOfWeek : null,
           nth_week: rRecType === 'monthly_nth_weekday' ? rNthWeek : null,
           biweekly_anchor: rRecType === 'biweekly' ? rAnchor || null : null,
+          notes: rNotes.trim() || null,
         }
         await onSaveRecurring(data)
       } else {
@@ -128,7 +137,7 @@ export default function TransactionModal({
         if (!aName.trim()) throw new Error('Name is required')
         if (isNaN(amt) || amt <= 0) throw new Error('Amount must be a positive number')
         if (!aDate) throw new Error('Date is required')
-        const adhocData = { type: aType, name: aName.trim(), amount: amt, date: aDate }
+        const adhocData = { type: aType, name: aName.trim(), amount: amt, date: aDate, notes: aNotes.trim() || null }
         if (editAdhoc && onUpdateAdhoc) {
           await onUpdateAdhoc(adhocData)
         } else {
@@ -273,6 +282,14 @@ export default function TransactionModal({
                   </select>
                 </Field>
               )}
+              <Field label="Notes">
+                <textarea
+                  rows={2}
+                  value={rNotes}
+                  onChange={(e) => setRNotes(e.target.value)}
+                  className={INPUT_CLS}
+                />
+              </Field>
             </>
           ) : (
             <>
@@ -293,6 +310,14 @@ export default function TransactionModal({
                   type="date"
                   value={aDate}
                   onChange={(e) => setADate(e.target.value)}
+                  className={INPUT_CLS}
+                />
+              </Field>
+              <Field label="Notes">
+                <textarea
+                  rows={2}
+                  value={aNotes}
+                  onChange={(e) => setANotes(e.target.value)}
                   className={INPUT_CLS}
                 />
               </Field>

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface RecurringTransaction {
   day_of_week: number | null
   nth_week: number | null
   biweekly_anchor: string | null
+  notes: string | null
   active: number
   created_at: string
 }
@@ -33,6 +34,7 @@ export interface AdhocTransaction {
   name: string
   amount: number
   date: string
+  notes: string | null
   created_at: string
 }
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -230,6 +230,7 @@ async function postRecurring(env: Env, req: Request, userId: string): Promise<Re
     day_of_week?: number | null
     nth_week?: number | null
     biweekly_anchor?: string | null
+    notes?: string | null
   }>()
 
   if (!body.type || !body.name || typeof body.amount !== 'number' || !body.recurrence_type) {
@@ -239,15 +240,15 @@ async function postRecurring(env: Env, req: Request, userId: string): Promise<Re
   const id = crypto.randomUUID()
   await env.DB.prepare(
     `INSERT INTO recurring_transactions
-       (id, user_id, type, name, amount, recurrence_type, day_of_month, month, day_of_week, nth_week, biweekly_anchor)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       (id, user_id, type, name, amount, recurrence_type, day_of_month, month, day_of_week, nth_week, biweekly_anchor, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
     .bind(
       id, userId,
       body.type, body.name, body.amount, body.recurrence_type,
       body.day_of_month ?? null, body.month ?? null,
       body.day_of_week ?? null, body.nth_week ?? null,
-      body.biweekly_anchor ?? null
+      body.biweekly_anchor ?? null, body.notes ?? null
     )
     .run()
 
@@ -273,6 +274,7 @@ async function putRecurring(env: Env, req: Request, id: string, userId: string):
     day_of_week?: number | null
     nth_week?: number | null
     biweekly_anchor?: string | null
+    notes?: string | null
   }>()
 
   await env.DB.prepare(
@@ -285,7 +287,8 @@ async function putRecurring(env: Env, req: Request, id: string, userId: string):
          month = ?,
          day_of_week = ?,
          nth_week = ?,
-         biweekly_anchor = ?
+         biweekly_anchor = ?,
+         notes = ?
      WHERE id = ? AND user_id = ?`
   )
     .bind(
@@ -293,7 +296,7 @@ async function putRecurring(env: Env, req: Request, id: string, userId: string):
       body.amount ?? null, body.recurrence_type ?? null,
       body.day_of_month ?? null, body.month ?? null,
       body.day_of_week ?? null, body.nth_week ?? null,
-      body.biweekly_anchor ?? null,
+      body.biweekly_anchor ?? null, body.notes ?? null,
       id, userId
     )
     .run()
@@ -327,6 +330,7 @@ async function postAdhoc(env: Env, req: Request, userId: string): Promise<Respon
     name?: string
     amount?: unknown
     date?: string
+    notes?: string | null
   }>()
 
   if (!body.type || !body.name || typeof body.amount !== 'number' || !body.date) {
@@ -335,8 +339,8 @@ async function postAdhoc(env: Env, req: Request, userId: string): Promise<Respon
 
   const id = crypto.randomUUID()
   await env.DB.prepare(
-    'INSERT INTO adhoc_transactions (id, user_id, type, name, amount, date) VALUES (?, ?, ?, ?, ?, ?)'
-  ).bind(id, userId, body.type, body.name, body.amount, body.date).run()
+    'INSERT INTO adhoc_transactions (id, user_id, type, name, amount, date, notes) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  ).bind(id, userId, body.type, body.name, body.amount, body.date, body.notes ?? null).run()
 
   const row = await env.DB.prepare(
     'SELECT * FROM adhoc_transactions WHERE id = ?'
@@ -349,13 +353,14 @@ async function putAdhoc(env: Env, req: Request, id: string, userId: string): Pro
     'SELECT id FROM adhoc_transactions WHERE id = ? AND user_id = ?'
   ).bind(id, userId).first()
   if (!existing) return notFound()
-  const body = await req.json<{ type?: string; name?: string; amount?: number; date?: string }>()
+  const body = await req.json<{ type?: string; name?: string; amount?: number; date?: string; notes?: string | null }>()
   await env.DB.prepare(
     `UPDATE adhoc_transactions
      SET type = COALESCE(?, type), name = COALESCE(?, name),
-         amount = COALESCE(?, amount), date = COALESCE(?, date)
+         amount = COALESCE(?, amount), date = COALESCE(?, date),
+         notes = ?
      WHERE id = ? AND user_id = ?`
-  ).bind(body.type ?? null, body.name ?? null, body.amount ?? null, body.date ?? null, id, userId).run()
+  ).bind(body.type ?? null, body.name ?? null, body.amount ?? null, body.date ?? null, body.notes ?? null, id, userId).run()
   const row = await env.DB.prepare(
     'SELECT * FROM adhoc_transactions WHERE id = ?'
   ).bind(id).first()


### PR DESCRIPTION
Adds an optional two-line Notes textarea to both the recurring and one-time
transaction forms. Stored in a new `notes TEXT` column on both DB tables via
migration 0005. The field is read and written by the worker but not displayed
anywhere outside the modals.

https://claude.ai/code/session_01CTkse5jkP82agAFpRcwdNn