### PR TITLE
Fix issue #5: apply DB migrations automatically on deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "deploy": "npm run build && wrangler deploy --config dist/budget_buddy/wrangler.json",
+    "deploy": "npm run build && wrangler d1 migrations apply DB --remote && wrangler deploy --config dist/budget_buddy/wrangler.json",
     "db:migrate": "wrangler d1 migrations apply DB --local",
     "db:migrate:remote": "wrangler d1 migrations apply DB --remote"
   },


### PR DESCRIPTION
The notes column added in migration 0005 was never applied to the production D1 database, causing all transaction saves to fail with HTTP 500. The deploy script now runs migrations before deploying the worker to prevent this from happening on future releases.

https://claude.ai/code/session_01Y5P8dJEF357axpbDGnt9RE