### PR TITLE
Fix balance input lag and select-all on tap

### DIFF
--- a/ios/BudgetBuddy/Networking/AppStore.swift
+++ b/ios/BudgetBuddy/Networking/AppStore.swift
@@ -4,53 +4,30 @@ import Observation
 @Observable
 @MainActor
 final class AppStore {
-    var balance: AccountBalance = .empty
-    var recurring: [RecurringTransaction] = []
-    var adhoc: [AdhocTransaction] = []
-    var skipped: [SkippedOccurrence] = []
+    var balance: AccountBalance = .empty { didSet { recomputeDailyBalances() } }
+    var recurring: [RecurringTransaction] = [] { didSet { recomputeDailyBalances() } }
+    var adhoc: [AdhocTransaction] = [] { didSet { recomputeDailyBalances() } }
+    var skipped: [SkippedOccurrence] = [] { didSet { recomputeDailyBalances() } }
 
     var loading = false
     var lastError: String?
 
+    private(set) var dailyBalances: [String: DayBalance] = [:]
+    private(set) var lowestBalance: (amount: Double, date: String)?
+
     /// Forecast window: 3 months back, 18 months forward — same range the web app uses.
-    var fromDate: String {
+    private var fromDate: String {
         let cal = Calendar.gregorian
         let from = cal.date(byAdding: .month, value: -3, to: Date()) ?? Date()
         let firstOfMonth = cal.date(from: cal.dateComponents([.year, .month], from: from)) ?? from
         return Calendar.ymdString(firstOfMonth)
     }
-    var toDate: String {
+    private var toDate: String {
         let cal = Calendar.gregorian
         let to = cal.date(byAdding: .month, value: 19, to: Date()) ?? Date()
         let firstOfNext = cal.date(from: cal.dateComponents([.year, .month], from: to)) ?? to
         let lastOfPrev = cal.date(byAdding: .day, value: -1, to: firstOfNext) ?? to
         return Calendar.ymdString(lastOfPrev)
-    }
-
-    var dailyBalances: [String: DayBalance] {
-        let today = Calendar.todayYMD()
-        let anchor = balance.balance_date ?? today
-        let cutoff = balance.cutoff_date ?? String(today.prefix(7)) + "-01"
-        return Balance.computeDaily(
-            startBalance: balance.amount,
-            startDate: anchor,
-            recurring: recurring,
-            adhoc: adhoc,
-            skipped: skipped,
-            cutoffDate: cutoff,
-            fromDate: fromDate,
-            toDate: toDate
-        )
-    }
-
-    /// Lowest projected end-of-day balance + the date it occurs.
-    var lowestBalance: (amount: Double, date: String)? {
-        var best: (Double, String)?
-        for (date, day) in dailyBalances {
-            guard let v = day.endBalance else { continue }
-            if best == nil || v < best!.0 { best = (v, date) }
-        }
-        return best.map { (amount: $0.0, date: $0.1) }
     }
 
     func load(api: APIClient) async {
@@ -78,5 +55,27 @@ final class AppStore {
         adhoc = []
         skipped = []
         lastError = nil
+    }
+
+    private func recomputeDailyBalances() {
+        let today = Calendar.todayYMD()
+        let anchor = balance.balance_date ?? today
+        let cutoff = balance.cutoff_date ?? String(today.prefix(7)) + "-01"
+        dailyBalances = Balance.computeDaily(
+            startBalance: balance.amount,
+            startDate: anchor,
+            recurring: recurring,
+            adhoc: adhoc,
+            skipped: skipped,
+            cutoffDate: cutoff,
+            fromDate: fromDate,
+            toDate: toDate
+        )
+        var best: (Double, String)?
+        for (date, day) in dailyBalances {
+            guard let v = day.endBalance else { continue }
+            if best == nil || v < best!.0 { best = (v, date) }
+        }
+        lowestBalance = best.map { (amount: $0.0, date: $0.1) }
     }
 }

--- a/ios/BudgetBuddy/Views/CalendarView.swift
+++ b/ios/BudgetBuddy/Views/CalendarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Home screen — Calendar V3 from the wireframes:
 /// header with Today's / Low Balance, forecast chart, then upcoming list.
@@ -9,6 +10,7 @@ struct CalendarView: View {
 
     @State private var balanceDraft: String = ""
     @State private var balanceEditing = false
+    @FocusState private var balanceFieldFocused: Bool
     @State private var addOpen = false
     @State private var editingRecurring: RecurringTransaction?
     @State private var editingAdhoc: AdhocTransaction?
@@ -128,11 +130,21 @@ struct CalendarView: View {
                             .keyboardType(.decimalPad)
                             .font(.system(size: 32, weight: .bold, design: .rounded))
                             .submitLabel(.done)
+                            .focused($balanceFieldFocused)
                             .onSubmit { commitBalance() }
+                            .onAppear {
+                                DispatchQueue.main.async {
+                                    UIApplication.shared.sendAction(
+                                        #selector(UIResponder.selectAll(_:)),
+                                        to: nil, from: nil, for: nil
+                                    )
+                                }
+                            }
                     } else {
                         Button {
                             balanceDraft = String(format: "%.2f", store.balance.amount)
                             balanceEditing = true
+                            balanceFieldFocused = true
                         } label: {
                             Text(store.balance.amount.asCurrency)
                                 .font(.system(size: 32, weight: .bold, design: .rounded))


### PR DESCRIPTION
## Summary

- **Typing lag**: `dailyBalances` was a computed property on `AppStore` that called `Balance.computeDaily(...)` (iterating ~630 days) on every SwiftUI view render — including every keystroke. Converted to a stored `private(set) var` with `didSet` observers on `balance`, `recurring`, `adhoc`, and `skipped` so the computation only runs when data actually changes. Also cached `lowestBalance` in the same pass. Reads during rendering are now O(1).
- **Select-all on tap**: Added `@FocusState` to `CalendarView` and wired it to the balance `TextField`. On tap, focus is set immediately. On `TextField` appear, `UIResponder.selectAll` is dispatched so all existing digits are selected — the first keystroke replaces the value entirely instead of appending.

Closes #14

## Test plan

- [ ] Tap Today's Balance → field opens with all text selected
- [ ] Type a new number → existing value is immediately replaced (no manual delete needed)
- [ ] Each keystroke appears instantly with no visible lag
- [ ] Saving/cancelling still works correctly
- [ ] Balance, forecast chart, and low balance still update correctly after save
- [ ] Pull-to-refresh still reloads all data

🤖 Generated with [Claude Code](https://claude.com/claude-code)