### PR TITLE
Add drag scrubber and scale picker to iOS forecast chart

### DIFF
--- a/ios/BudgetBuddy/Views/CalendarView.swift
+++ b/ios/BudgetBuddy/Views/CalendarView.swift
@@ -33,10 +33,8 @@ struct CalendarView: View {
                     if !store.upcomingFlat.isEmpty {
                         ForecastChart(
                             dailyBalances: store.dailyBalances,
-                            lowDate: store.lowestBalance?.date,
-                            days: 30
+                            lowDate: store.lowestBalance?.date
                         )
-                        .padding(.horizontal)
                         .listRowInsets(EdgeInsets())
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)

--- a/ios/BudgetBuddy/Views/ForecastChart.swift
+++ b/ios/BudgetBuddy/Views/ForecastChart.swift
@@ -1,11 +1,17 @@
 import SwiftUI
 import Charts
 
-/// Compact end-of-day balance forecast — used in the calendar header.
+/// Compact end-of-day balance forecast with scale picker and drag-to-scrub.
 struct ForecastChart: View {
     let dailyBalances: [String: DayBalance]
     let lowDate: String?
-    let days: Int
+
+    @State private var selectedDays: Int = 30
+    @State private var scrubDate: Date? = nil
+    @State private var scrubBalance: Double? = nil
+    @State private var isScrubbing: Bool = false
+
+    private let scaleOptions = [7, 30, 60, 90]
 
     var body: some View {
         let pts = points()
@@ -13,43 +19,103 @@ struct ForecastChart: View {
         let yMax = pts.map(\.balance).max() ?? 0
         let yPad = max(1, (yMax - yMin) * 0.15)
 
-        Chart {
-            ForEach(pts) { p in
-                LineMark(
-                    x: .value("Day", p.date),
-                    y: .value("Balance", p.balance)
-                )
-                .foregroundStyle(Color.primary)
-                .interpolationMethod(.monotone)
+        VStack(spacing: 6) {
+            Picker("Range", selection: $selectedDays) {
+                ForEach(scaleOptions, id: \.self) { d in
+                    Text("\(d)d").tag(d)
+                }
+            }
+            .pickerStyle(.segmented)
 
-                if Calendar.ymdString(p.date) == lowDate {
-                    PointMark(
+            // Fixed-height scrub info row — opacity-toggled so the chart never shifts
+            HStack {
+                if let d = scrubDate, let b = scrubBalance {
+                    Text(d.formatted(.dateTime.weekday(.abbreviated).month(.abbreviated).day()))
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(b.asCurrency)
+                        .font(.caption.monospacedDigit().bold())
+                }
+            }
+            .frame(height: 16)
+            .opacity(isScrubbing ? 1 : 0)
+
+            Chart {
+                ForEach(pts) { p in
+                    LineMark(
                         x: .value("Day", p.date),
                         y: .value("Balance", p.balance)
                     )
-                    .foregroundStyle(Color.bbWarning)
-                    .symbolSize(80)
-                    .annotation(position: .top) {
-                        Text(p.balance.asCurrency)
-                            .font(.caption2.bold())
-                            .foregroundStyle(Color.bbWarning)
+                    .foregroundStyle(Color.primary)
+                    .interpolationMethod(.monotone)
+
+                    if Calendar.ymdString(p.date) == lowDate {
+                        PointMark(
+                            x: .value("Day", p.date),
+                            y: .value("Balance", p.balance)
+                        )
+                        .foregroundStyle(Color.bbWarning)
+                        .symbolSize(80)
+                        .annotation(position: .top) {
+                            if !isScrubbing {
+                                Text(p.balance.asCurrency)
+                                    .font(.caption2.bold())
+                                    .foregroundStyle(Color.bbWarning)
+                            }
+                        }
+                    }
+                }
+
+                if isScrubbing, let sd = scrubDate {
+                    RuleMark(x: .value("Scrub", sd))
+                        .foregroundStyle(Color.primary.opacity(0.18))
+                        .lineStyle(StrokeStyle(lineWidth: 1))
+                }
+
+                if isScrubbing, let sd = scrubDate, let sb = scrubBalance {
+                    PointMark(
+                        x: .value("Scrub", sd),
+                        y: .value("Balance", sb)
+                    )
+                    .foregroundStyle(Color.primary)
+                    .symbolSize(40)
+                    .symbol(.circle)
+                }
+            }
+            .chartYScale(domain: (yMin - yPad)...(yMax + yPad))
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day, count: max(1, selectedDays / 6))) { value in
+                    if let date = value.as(Date.self) {
+                        AxisValueLabel {
+                            Text(Calendar.gregorian.component(.day, from: date), format: .number)
+                                .font(.caption2)
+                        }
                     }
                 }
             }
-        }
-        .chartYScale(domain: (yMin - yPad)...(yMax + yPad))
-        .chartXAxis {
-            AxisMarks(values: .stride(by: .day, count: max(1, days / 6))) { value in
-                if let date = value.as(Date.self) {
-                    AxisValueLabel {
-                        Text(Calendar.gregorian.component(.day, from: date), format: .number)
-                            .font(.caption2)
-                    }
+            .chartYAxis(.hidden)
+            .frame(height: 120)
+            .chartOverlay { proxy in
+                GeometryReader { geo in
+                    Rectangle()
+                        .fill(Color.clear)
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture(minimumDistance: 0)
+                                .onChanged { value in
+                                    updateScrub(at: value.location, proxy: proxy, geo: geo, pts: pts)
+                                }
+                                .onEnded { _ in
+                                    isScrubbing = false
+                                    scrubDate = nil
+                                    scrubBalance = nil
+                                }
+                        )
                 }
             }
         }
-        .chartYAxis(.hidden)
-        .frame(height: 90)
+        .padding(.horizontal)
     }
 
     private struct Point: Identifiable {
@@ -63,7 +129,7 @@ struct ForecastChart: View {
         guard let start = Calendar.parseYMD(today) else { return [] }
         let cal = Calendar.gregorian
         var result: [Point] = []
-        for offset in 0..<days {
+        for offset in 0..<selectedDays {
             guard let d = cal.date(byAdding: .day, value: offset, to: start) else { continue }
             let key = Calendar.ymdString(d)
             if let day = dailyBalances[key], let b = day.endBalance {
@@ -71,5 +137,17 @@ struct ForecastChart: View {
             }
         }
         return result
+    }
+
+    private func updateScrub(at location: CGPoint, proxy: ChartProxy, geo: GeometryProxy, pts: [Point]) {
+        guard let frame = proxy.plotFrame else { return }
+        let relativeX = location.x - geo[frame].minX
+        guard let date: Date = proxy.value(atX: relativeX, as: Date.self) else { return }
+        guard let closest = pts.min(by: {
+            abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
+        }) else { return }
+        scrubDate = closest.date
+        scrubBalance = closest.balance
+        isScrubbing = true
     }
 }


### PR DESCRIPTION
## Summary

Brings the iOS forecast chart to parity with the web version on two fronts:

- **Scale picker**: Segmented control above the chart lets the user choose between 7d / 30d / 60d / 90d windows, matching the web's range buttons. State is fully self-contained in `ForecastChart` — no prop needed from `CalendarView`.
- **Drag scrubber**: Touch and drag horizontally across the chart to see each day's projected balance. A vertical rule line and circle marker track the finger (snapping to the nearest data point via `ChartProxy.value(atX:as:)`). A fixed-height info row above the chart shows the formatted date (e.g. "Tue, Apr 29") and balance — it occupies space unconditionally so the chart doesn't shift when scrubbing starts. The low-balance annotation text is suppressed while scrubbing to prevent overlap; the amber dot remains visible.

### Note on gesture conflict
`ForecastChart` lives inside a `List`. The `DragGesture(minimumDistance: 0)` competes with the list's vertical scroll when a touch starts on the chart. In practice SwiftUI correctly routes horizontal drags to the chart and vertical drags to the list, but if testing reveals sluggish scroll initiation from the chart area, change `minimumDistance` from `0` to `8`.

## Test plan

- [ ] Segmented picker shows 7d / 30d / 60d / 90d; selecting each updates the chart range
- [ ] Dragging horizontally across the chart shows the info row with date + balance updating in real time
- [ ] Scrub rule line and circle dot track the finger, snapping to data points
- [ ] Lifting finger clears the scrub state; low-balance annotation text reappears
- [ ] Vertical list scroll still works when drag starts outside the chart
- [ ] Low-balance dot and annotation render correctly when not scrubbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)