### PR TITLE
Fix recurring transactions not honoring start date

### DIFF
--- a/ios/BudgetBuddy/Logic/Balance.swift
+++ b/ios/BudgetBuddy/Logic/Balance.swift
@@ -100,6 +100,7 @@ enum Balance {
             for rule in recurring where rule.active != 0 {
                 for date in Recurrence.expand(rule, year: y, month: m) {
                     if date < fromDate || date > toDate { continue }
+                    if let sd = rule.start_date, date < sd { continue }
                     let skippedId = skipMap["\(rule.id)|\(date)"]
                     let paidId = paidMap["\(rule.id)|\(date)"]
                     let entry = TxEntry(

--- a/ios/BudgetBuddy/Transaction.swift
+++ b/ios/BudgetBuddy/Transaction.swift
@@ -34,6 +34,7 @@ struct RecurringTransaction: Codable, Identifiable, Hashable {
     var day_of_week: Int?
     var nth_week: Int?
     var biweekly_anchor: String?
+    var start_date: String?
     var notes: String?
     var active: Int
     var created_at: String
@@ -60,6 +61,7 @@ struct NewRecurring: Codable {
     var day_of_week: Int?
     var nth_week: Int?
     var biweekly_anchor: String?
+    var start_date: String?
     var notes: String?
 }
 

--- a/migrations/0007_recurring_start_date.sql
+++ b/migrations/0007_recurring_start_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE recurring_transactions ADD COLUMN start_date TEXT;

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -32,6 +32,7 @@ const DEFAULT_RECURRING: Omit<RecurringTransaction, 'id' | 'active' | 'created_a
   day_of_week: null,
   nth_week: null,
   biweekly_anchor: null,
+  start_date: null,
   notes: null,
 }
 
@@ -59,6 +60,7 @@ export default function TransactionModal({
   const [rDayOfWeek, setRDayOfWeek] = useState(editRecurring?.day_of_week ?? 5)
   const [rNthWeek, setRNthWeek] = useState(editRecurring?.nth_week ?? 1)
   const [rAnchor, setRAnchor] = useState(editRecurring?.biweekly_anchor ?? '')
+  const [rStartDate, setRStartDate] = useState(editRecurring?.start_date ?? '')
 
   // Recurring notes state
   const [rNotes, setRNotes] = useState(editRecurring?.notes ?? '')
@@ -97,6 +99,7 @@ export default function TransactionModal({
     setRDayOfWeek(editRecurring?.day_of_week ?? 5)
     setRNthWeek(editRecurring?.nth_week ?? 1)
     setRAnchor(editRecurring?.biweekly_anchor ?? '')
+    setRStartDate(editRecurring?.start_date ?? '')
     setRNotes(editRecurring?.notes ?? '')
 
     // Reset one-time fields
@@ -128,7 +131,8 @@ export default function TransactionModal({
           month: rRecType === 'yearly' ? rMonth : null,
           day_of_week: ['weekly', 'biweekly', 'monthly_nth_weekday'].includes(rRecType) ? rDayOfWeek : null,
           nth_week: rRecType === 'monthly_nth_weekday' ? rNthWeek : null,
-          biweekly_anchor: rRecType === 'biweekly' ? rAnchor || null : null,
+          biweekly_anchor: rRecType === 'biweekly' ? (rStartDate || rAnchor || null) : null,
+          start_date: rStartDate || null,
           notes: rNotes.trim() || null,
         }
         await onSaveRecurring(data)
@@ -262,17 +266,6 @@ export default function TransactionModal({
                   </select>
                 </Field>
               )}
-              {rRecType === 'biweekly' && (
-                <Field label="Starting date">
-                  <input
-                    type="date"
-                    value={rAnchor}
-                    onChange={(e) => setRAnchor(e.target.value)}
-                    className={INPUT_CLS}
-                  />
-                  <p className="text-xs text-gray-400 mt-0.5">Pick any past occurrence of this transaction</p>
-                </Field>
-              )}
               {rRecType === 'monthly_nth_weekday' && (
                 <Field label="Which occurrence">
                   <select value={rNthWeek} onChange={(e) => setRNthWeek(Number(e.target.value))} className={INPUT_CLS}>
@@ -282,6 +275,15 @@ export default function TransactionModal({
                   </select>
                 </Field>
               )}
+              <Field label="Start date">
+                <input
+                  type="date"
+                  value={rStartDate}
+                  onChange={(e) => setRStartDate(e.target.value)}
+                  className={INPUT_CLS}
+                />
+                <p className="text-xs text-gray-400 mt-0.5">Leave blank to start immediately</p>
+              </Field>
               <Field label="Notes">
                 <textarea
                   rows={2}

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -39,6 +39,7 @@ function buildTxMap(
       if (!rule.active) continue
       for (const date of expandRecurring(rule, y, m)) {
         if (date < fromDate || date > toDate) continue
+        if (rule.start_date && date < rule.start_date) continue
         const skippedId = skipMap.get(`${rule.id}|${date}`) ?? null
         const paidId = paidMap.get(`${rule.id}|${date}`) ?? null
         const day = ensure(date)

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface RecurringTransaction {
   day_of_week: number | null
   nth_week: number | null
   biweekly_anchor: string | null
+  start_date: string | null
   notes: string | null
   active: number
   created_at: string

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -262,6 +262,7 @@ async function postRecurring(env: Env, req: Request, userId: string): Promise<Re
     day_of_week?: number | null
     nth_week?: number | null
     biweekly_anchor?: string | null
+    start_date?: string | null
     notes?: string | null
   }>()
 
@@ -280,15 +281,15 @@ async function postRecurring(env: Env, req: Request, userId: string): Promise<Re
   const id = crypto.randomUUID()
   await env.DB.prepare(
     `INSERT INTO recurring_transactions
-       (id, user_id, type, name, amount, recurrence_type, day_of_month, month, day_of_week, nth_week, biweekly_anchor, notes)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       (id, user_id, type, name, amount, recurrence_type, day_of_month, month, day_of_week, nth_week, biweekly_anchor, start_date, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
     .bind(
       id, userId,
       body.type, body.name, body.amount, body.recurrence_type,
       body.day_of_month ?? null, body.month ?? null,
       body.day_of_week ?? null, body.nth_week ?? null,
-      body.biweekly_anchor ?? null, body.notes ?? null
+      body.biweekly_anchor ?? null, body.start_date ?? null, body.notes ?? null
     )
     .run()
 
@@ -314,6 +315,7 @@ async function putRecurring(env: Env, req: Request, id: string, userId: string):
     day_of_week?: number | null
     nth_week?: number | null
     biweekly_anchor?: string | null
+    start_date?: string | null
     notes?: string | null
   }>()
 
@@ -340,6 +342,7 @@ async function putRecurring(env: Env, req: Request, id: string, userId: string):
          day_of_week = ?,
          nth_week = ?,
          biweekly_anchor = ?,
+         start_date = ?,
          notes = ?
      WHERE id = ? AND user_id = ?`
   )
@@ -348,7 +351,7 @@ async function putRecurring(env: Env, req: Request, id: string, userId: string):
       body.amount ?? null, body.recurrence_type ?? null,
       body.day_of_month ?? null, body.month ?? null,
       body.day_of_week ?? null, body.nth_week ?? null,
-      body.biweekly_anchor ?? null, body.notes ?? null,
+      body.biweekly_anchor ?? null, body.start_date ?? null, body.notes ?? null,
       id, userId
     )
     .run()


### PR DESCRIPTION
## Summary

- Adds a `start_date` column to `recurring_transactions` so each rule can specify when it becomes active
- Filters out expanded recurrence dates before `start_date` in both the web (`balance.ts`) and iOS (`Balance.swift`) balance engines
- Updates the `TransactionModal` to expose a "Start date" field for all recurrence types; for biweekly, this date also serves as the `biweekly_anchor` (replacing the confusing "Pick any past occurrence" UX)

Fixes #17

## Test plan

- [ ] Create a biweekly recurring expense with a start date 2+ weeks in the future — confirm it does not appear in past months
- [ ] Create a monthly_fixed recurring expense with a start date next month — confirm it does not appear in the current month
- [ ] Verify existing recurring transactions (no start_date) are unaffected
- [ ] Edit an existing biweekly transaction — confirm start_date field is blank and saving without one still works

https://claude.ai/code/session_018umfyNoR35i98XRsU51kCx

---
_Generated by [Claude Code](https://claude.ai/code/session_018umfyNoR35i98XRsU51kCx)_